### PR TITLE
add FLAG_IMMUTABLE at TaskScheduler.java

### DIFF
--- a/app/src/main/java/kr/apptimer/dagger/android/TaskScheduler.java
+++ b/app/src/main/java/kr/apptimer/dagger/android/TaskScheduler.java
@@ -109,7 +109,7 @@ public final class TaskScheduler {
         intent.putExtra(InjectApplicationContext.KEY_NAME, application.getName());
         intent.putExtra(InjectApplicationContext.KEY_PACKAGE_URI, application.getPackageUri());
 
-        PendingIntent pendingIntent = PendingIntent.getBroadcast(context, 0, intent, PendingIntent.FLAG_UPDATE_CURRENT);
+        PendingIntent pendingIntent = PendingIntent.getBroadcast(context, 0, intent, PendingIntent.FLAG_UPDATE_CURRENT|PendingIntent.FLAG_IMMUTABLE);
 
         cache.putCache(application.getPackageUri(), pendingIntent);
         alarmManager.set(AlarmManager.RTC_WAKEUP, time.getTime(), pendingIntent);


### PR DESCRIPTION
Following error has occured when get notification, and fixed.


FATAL EXCEPTION: main
                                                                                             Process: kr.apptimer, PID: 5975
                                                                                             java.lang.IllegalArgumentException: kr.apptimer: Targeting S+ (version 31 and above) requires that one of FLAG_IMMUTABLE or FLAG_MUTABLE be specified when creating a PendingIntent.
                                                                                             Strongly consider using FLAG_IMMUTABLE, only use FLAG_MUTABLE if some functionality depends on the PendingIntent being mutable, e.g. if it needs to be used with inline replies or bubbles.